### PR TITLE
Reorder tests for method_missing

### DIFF
--- a/src/about_message_passing.rb
+++ b/src/about_message_passing.rb
@@ -72,6 +72,31 @@ class AboutMessagePassing < Neo::Koan
 
   # ------------------------------------------------------------------
 
+  class AllMessageCatcher
+    def method_missing(method_name, *args, &block)
+      "Someone called #{method_name} with <#{args.join(", ")}>"
+    end
+  end
+
+  def test_all_messages_are_caught
+    catcher = AllMessageCatcher.new
+
+    assert_equal __("Someone called foobar with <>"), catcher.foobar
+    assert_equal __("Someone called foobaz with <1>"), catcher.foobaz(1)
+    assert_equal __("Someone called sum with <1, 2, 3, 4, 5, 6>"), catcher.sum(1,2,3,4,5,6)
+  end
+
+  def test_catching_messages_makes_respond_to_lie
+    catcher = AllMessageCatcher.new
+
+    assert_nothing_raised do # __
+      catcher.any_method
+    end
+    assert_equal __(false), catcher.respond_to?(:any_method)
+  end
+
+  # ------------------------------------------------------------------
+
   class TypicalObject
   end
 
@@ -109,32 +134,7 @@ class AboutMessagePassing < Neo::Koan
     # Thanks.  We now return you to your regularly scheduled Ruby
     # Koans.
   end
-
-  # ------------------------------------------------------------------
-
-  class AllMessageCatcher
-    def method_missing(method_name, *args, &block)
-      "Someone called #{method_name} with <#{args.join(", ")}>"
-    end
-  end
-
-  def test_all_messages_are_caught
-    catcher = AllMessageCatcher.new
-
-    assert_equal __("Someone called foobar with <>"), catcher.foobar
-    assert_equal __("Someone called foobaz with <1>"), catcher.foobaz(1)
-    assert_equal __("Someone called sum with <1, 2, 3, 4, 5, 6>"), catcher.sum(1,2,3,4,5,6)
-  end
-
-  def test_catching_messages_makes_respond_to_lie
-    catcher = AllMessageCatcher.new
-
-    assert_nothing_raised do # __
-      catcher.any_method
-    end
-    assert_equal __(false), catcher.respond_to?(:any_method)
-  end
-
+  
   # ------------------------------------------------------------------
 
   class WellBehavedFooCatcher


### PR DESCRIPTION
The current order assumes some knowledge of what method_missing does especially the note to think about it. Having never been exposed to method_missing before I found it confusing. I think the teaching would go smoother here if method_missing is introduced first before the reader is asked to think about it.